### PR TITLE
Add ConfigureAwait code analyzer to CodeRules project

### DIFF
--- a/packaging/nuget/Particular.CodeRules.nuspec
+++ b/packaging/nuget/Particular.CodeRules.nuspec
@@ -12,7 +12,6 @@
         <dependencies>
             <dependency id="RefactoringEssentials" version="2.1.0" />
             <dependency id="StyleCop.Analyzers" version="1.0.0" />
-            <dependency id="Microsoft.CodeAnalysis" version="[1.1.1]" />
         </dependencies>
     </metadata>
     <files>

--- a/packaging/nuget/Particular.CodeRules.nuspec
+++ b/packaging/nuget/Particular.CodeRules.nuspec
@@ -3,17 +3,23 @@
     <metadata>
         <id>Particular.CodeRules</id>
         <version>$version$</version>
+        <title>Particular.CodeRules</title>
         <authors>Particular</authors>
+        <owners>Particular</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <developmentDependency>true</developmentDependency>
-        <description>Build assets for enforcing coding style.</description>
+        <description>Build assets and code analyzers for enforcing coding style.</description>
         <dependencies>
             <dependency id="RefactoringEssentials" version="2.1.0" />
-            <dependency id="StyleCop.Analyzers" version="1.0.0-beta015" />
+            <dependency id="StyleCop.Analyzers" version="1.0.0" />
+            <dependency id="Microsoft.CodeAnalysis" version="[1.1.1]" />
         </dependencies>
     </metadata>
     <files>
         <file src="..\..\src\Particular.CodeRules\Particular.CodeRules.props" target="build\Particular.CodeRules.props" />
         <file src="..\..\src\Particular.CodeRules\Particular.ruleset" target="build\Particular.ruleset" />
+
+        <file src="..\..\src\Particular.CodeRules\bin\Release\*.dll" target="analyzers\dotnet\cs" exclude="**\System.Reflection.Metadata.*;" />
+        <file src="..\..\src\Particular.CodeRules\tools\*.ps1" target="tools\" />
     </files>
 </package>

--- a/src/Particular.CodeRules/Analyzers/ConfigureAwait/ConfigureAwaitAnalyzer.cs
+++ b/src/Particular.CodeRules/Analyzers/ConfigureAwait/ConfigureAwaitAnalyzer.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Particular.CodeRules.Analyzers.ConfigureAwait
+{
+    /// <summary>
+    ///     The analyzer to identify any missing ConfigureAwaits
+    /// </summary>
+    /// <seealso cref="Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer" />
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class ConfigureAwaitAnalyzer : DiagnosticAnalyzer
+    {
+        /// <summary>
+        ///     The rule identifier for the configure await analyzer. Particular Code Rules 0001
+        /// </summary>
+        public const string RuleIdentifier = "PCR0001";
+
+        internal static DiagnosticDescriptor RuleDescriptor = new DiagnosticDescriptor(RuleIdentifier,
+            "Await used without specifying ConfigureAwait", "Await used without specifying ConfigureAwait", "Usage",
+            DiagnosticSeverity.Warning, true);
+
+        /// <summary>
+        ///     Gets the list of supported diagnostics for the analyzer.
+        /// </summary>
+        /// <value>
+        ///     The supported diagnostics.
+        /// </value>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(RuleDescriptor);
+
+        /// <summary>
+        ///     Initializes the specified analyzer on the <paramref name="context" />.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(AnalyzeForConfigureFalse, SyntaxKind.AwaitExpression);
+        }
+
+        private void AnalyzeForConfigureFalse(SyntaxNodeAnalysisContext context)
+        {
+            var node = (AwaitExpressionSyntax) context.Node;
+            if (node.Expression != null)
+            {
+                var type = ModelExtensions.GetTypeInfo(context.SemanticModel, node.Expression).Type;
+                if (type.ContainingNamespace.ToString() == "System.Threading.Tasks" && type.Name == "Task")
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(RuleDescriptor, node.GetLocation()));
+                }
+            }
+        }
+    }
+}

--- a/src/Particular.CodeRules/Analyzers/ConfigureAwait/ConfigureAwaitAnalyzer.cs
+++ b/src/Particular.CodeRules/Analyzers/ConfigureAwait/ConfigureAwaitAnalyzer.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Particular.CodeRules.Analyzers.ConfigureAwait
+﻿namespace Particular.CodeRules.Analyzers.ConfigureAwait
 {
+    using System.Collections.Immutable;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
     /// <summary>
     ///     The analyzer to identify any missing ConfigureAwaits
     /// </summary>

--- a/src/Particular.CodeRules/Analyzers/ConfigureAwait/ConfigureAwaitCodeFix.cs
+++ b/src/Particular.CodeRules/Analyzers/ConfigureAwait/ConfigureAwaitCodeFix.cs
@@ -1,15 +1,15 @@
-﻿using System.Collections.Immutable;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
-namespace Particular.CodeRules.Analyzers.ConfigureAwait
+﻿namespace Particular.CodeRules.Analyzers.ConfigureAwait
 {
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+
     /// <summary>
     ///     The code fix for any missing ConfigureAwaits
     /// </summary>
@@ -24,6 +24,15 @@ namespace Particular.CodeRules.Analyzers.ConfigureAwait
         ///     The fixable diagnostic ids.
         /// </value>
         public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(ConfigureAwaitAnalyzer.RuleIdentifier);
+
+        /// <summary>
+        /// Gets the fix all provider type
+        /// </summary>
+        /// <returns>The type of provider applicable</returns>
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
 
         /// <summary>
         ///     Registers the code fixes asynchronous.

--- a/src/Particular.CodeRules/Analyzers/ConfigureAwait/ConfigureAwaitCodeFix.cs
+++ b/src/Particular.CodeRules/Analyzers/ConfigureAwait/ConfigureAwaitCodeFix.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Particular.CodeRules.Analyzers.ConfigureAwait
+{
+    /// <summary>
+    ///     The code fix for any missing ConfigureAwaits
+    /// </summary>
+    /// <seealso cref="T:Microsoft.CodeAnalysis.CodeFixes.CodeFixProvider" />
+    [ExportCodeFixProvider(ConfigureAwaitAnalyzer.RuleIdentifier, LanguageNames.CSharp)]
+    public class ConfigureAwaitCodeFix : CodeFixProvider
+    {
+        /// <summary>
+        ///     Gets the fixable diagnostic ids.
+        /// </summary>
+        /// <value>
+        ///     The fixable diagnostic ids.
+        /// </value>
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(ConfigureAwaitAnalyzer.RuleIdentifier);
+
+        /// <summary>
+        ///     Registers the code fixes asynchronous.
+        /// </summary>
+        /// <param name="context">The <paramref name="context" /> .</param>
+        /// <returns>
+        /// </returns>
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+            var declaration = root.FindToken(diagnosticSpan.Start)
+                .Parent
+                .FirstAncestorOrSelf<AwaitExpressionSyntax>();
+
+            context.RegisterCodeFix(
+                CodeAction.Create("Add ConfigureAwait(true)",
+                    cancellationToken => AddConfigureAwait(context.Document, declaration, true, cancellationToken),
+                    "Add ConfigureAwait(true)"), diagnostic);
+        }
+
+        private Task<Document> AddConfigureAwait(Document document, AwaitExpressionSyntax awaitSyntax, bool value, CancellationToken cancellationToken)
+        {
+            var oldExpression = awaitSyntax.Expression;
+            var newExpression =
+                SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, oldExpression,
+                        SyntaxFactory.IdentifierName("ConfigureAwait")),
+                    SyntaxFactory.ArgumentList(
+                        SyntaxFactory.SingletonSeparatedList(
+                            SyntaxFactory.Argument(
+                                SyntaxFactory.LiteralExpression(
+                                    value ? SyntaxKind.TrueLiteralExpression : SyntaxKind.FalseLiteralExpression)))));
+
+            return ReplaceAsync(document, oldExpression, newExpression, cancellationToken);
+        }
+
+        private async Task<Document> ReplaceAsync(Document document, SyntaxNode oldSyntax, SyntaxNode newSyntax, CancellationToken cancellationToken)
+        {
+            var oldRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var newRoot = oldRoot.ReplaceNode(oldSyntax, newSyntax);
+            return document.WithSyntaxRoot(newRoot);
+        }
+    }
+}

--- a/src/Particular.CodeRules/Particular.CodeRules.csproj
+++ b/src/Particular.CodeRules/Particular.CodeRules.csproj
@@ -9,10 +9,16 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Particular.CodeRules</RootNamespace>
     <AssemblyName>Particular.CodeRules</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <GeneratePkgDefFile>false</GeneratePkgDefFile>
+    <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
+    <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
+    <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
+    <VSSDKTargetPlatformRegRootSuffix>Roslyn</VSSDKTargetPlatformRegRootSuffix>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -37,9 +43,90 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Particular.CodeRules.props" />
     <None Include="Particular.ruleset" />
+    <None Include="tools\install.ps1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="tools\uninstall.ps1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.1.1\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.1.1\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.1.1\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.1.1\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.1.1\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.1.1\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.1.1\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.Convention, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.Hosting, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.Runtime, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.TypedParts, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Analyzers\ConfigureAwait\ConfigureAwaitAnalyzer.cs" />
+    <Compile Include="Analyzers\ConfigureAwait\ConfigureAwaitCodeFix.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\Newtonsoft.Json.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/Particular.CodeRules/Particular.CodeRules.csproj
+++ b/src/Particular.CodeRules/Particular.CodeRules.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{3DEB4013-558D-4711-8622-E31CA878660D}</ProjectGuid>
@@ -9,19 +10,12 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Particular.CodeRules</RootNamespace>
     <AssemblyName>Particular.CodeRules</AssemblyName>
-    <GeneratePkgDefFile>false</GeneratePkgDefFile>
-    <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
-    <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
-    <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
-    <VSSDKTargetPlatformRegRootSuffix>Roslyn</VSSDKTargetPlatformRegRootSuffix>
-    <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -31,16 +25,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
   </PropertyGroup>
   <ItemGroup>
     <None Include="packages.config">
@@ -56,77 +46,61 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.1.1\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.1.1\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.1.1\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.1.1\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.1.1\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.1.1\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.1.1\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Composition.Convention, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Composition.Hosting, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Composition.Runtime, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Composition.TypedParts, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Analyzers\ConfigureAwait\ConfigureAwaitAnalyzer.cs" />
-    <Compile Include="Analyzers\ConfigureAwait\ConfigureAwaitCodeFix.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-  <ItemGroup>
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\Newtonsoft.Json.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Composition.Convention, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Composition.Hosting, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Composition.Runtime, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Composition.TypedParts, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata, Version=1.0.21.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.0.21\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Analyzers\ConfigureAwait\ConfigureAwaitAnalyzer.cs" />
+    <Compile Include="Analyzers\ConfigureAwait\ConfigureAwaitCodeFix.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/Particular.CodeRules/packages.config
+++ b/src/Particular.CodeRules/packages.config
@@ -1,5 +1,33 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GitVersionTask" version="1.3.2" targetFramework="net45" developmentDependency="true" />
-  <package id="NuGetPackager" version="0.5.5" targetFramework="net45" developmentDependency="true" />
+  <package id="GitVersionTask" version="1.3.2" targetFramework="net452" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis" version="1.1.1" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.1.1" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.1.1" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.1.1" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.1.1" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.1.1" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.1.1" targetFramework="net452" />
+  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
+  <package id="NuGet.CommandLine" version="3.3.0" targetFramework="net452" />
+  <package id="NuGetPackager" version="0.5.5" targetFramework="net452" developmentDependency="true" />
+  <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />
+  <package id="System.Collections" version="4.0.0" targetFramework="net452" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net452" />
+  <package id="System.Globalization" version="4.0.0" targetFramework="net452" />
+  <package id="System.IO" version="4.0.0" targetFramework="net452" />
+  <package id="System.Linq" version="4.0.0" targetFramework="net452" />
+  <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
+  <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices" version="4.0.0" targetFramework="net452" />
+  <package id="System.Text.Encoding" version="4.0.0" targetFramework="net452" />
+  <package id="System.Text.Encoding.Extensions" version="4.0.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.0.0" targetFramework="net452" />
 </packages>

--- a/src/Particular.CodeRules/packages.config
+++ b/src/Particular.CodeRules/packages.config
@@ -1,27 +1,27 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GitVersionTask" version="1.3.2" targetFramework="net452" developmentDependency="true" />
-  <package id="Microsoft.CodeAnalysis" version="1.1.1" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.1.1" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.1.1" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.1.1" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.1.1" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.1.1" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.1.1" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="NuGet.CommandLine" version="3.3.0" targetFramework="net452" />
   <package id="NuGetPackager" version="0.5.5" targetFramework="net452" developmentDependency="true" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
-  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
+  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net452" />
   <package id="System.Globalization" version="4.0.0" targetFramework="net452" />
   <package id="System.IO" version="4.0.0" targetFramework="net452" />
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/src/Particular.CodeRules/tools/install.ps1
+++ b/src/Particular.CodeRules/tools/install.ps1
@@ -1,0 +1,6 @@
+﻿param($installPath, $toolsPath, $package, $project)
+
+$analyzerPath = join-path $toolsPath "..\analyzers\dotnet\cs"
+$analyzerFilePath = join-path $analyzerPath "Particular.CodeRules.dll"
+
+$project.Object.AnalyzerReferences.Add("$analyzerFilePath")

--- a/src/Particular.CodeRules/tools/uninstall.ps1
+++ b/src/Particular.CodeRules/tools/uninstall.ps1
@@ -1,0 +1,6 @@
+﻿param($installPath, $toolsPath, $package, $project)
+
+$analyzerPath = join-path $toolsPath "..\analyzers\dotnet\cs"
+$analyzerFilePath = join-path $analyzerPath "Particular.CodeRules.dll"
+
+$project.Object.AnalyzerReferences.Remove("$analyzerFilePath")


### PR DESCRIPTION
Added code analyzer to check that configure await is called whenever a task is awaited. If the configure await is not used
then the code fix suggests adding configure await.

NuSpec project was also updated to bundle the required DLLs and perform the install into the VS Instance.

Connects to https://github.com/Particular/NServiceBus/issues/3340