### PR TITLE
Analyzer to catch tasks that aren’t either awaited or captured in a variable

### DIFF
--- a/src/Particular.CodeRules.Tests/AwaitOrCaptureTasksAnalyzerTests.cs
+++ b/src/Particular.CodeRules.Tests/AwaitOrCaptureTasksAnalyzerTests.cs
@@ -1,0 +1,250 @@
+﻿namespace Particular.CodeRules.Tests
+{
+    using System.Threading.Tasks;
+    using Particular.CodeRules.AwaitOrCaptureTasks;
+    using Xunit;
+
+    public class AwaitOrCaptureTasksAnalyzerTests : CSharpAnalyzerTestFixture<AwaitOrCaptureTasksAnalyzer>
+    {
+        [Fact]
+        public Task AwaitedTaskIsOk()
+        {
+            const string code = @"
+using System.Threading.Tasks;
+class C
+{
+    public async Task Foo()
+    {
+        await Task.Delay(1);
+    }
+}";
+            return NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+        }
+
+
+
+        [Fact]
+        public Task CapturedTaskIsOk()
+        {
+            const string code = @"
+using System.Threading.Tasks;
+class C
+{
+    public Task Foo()
+    {
+        var task = Task.Delay(1);
+        return task;
+    }
+}";
+            return NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+        }
+
+
+
+        [Fact]
+        public Task ReturnedTaskIsOk()
+        {
+            const string code = @"
+using System.Threading.Tasks;
+class C
+{
+    public Task Foo()
+    {
+        return Task.Delay(1);
+    }
+}";
+            return NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+        }
+
+
+
+        [Fact]
+        public Task TaskIsDropped()
+        {
+            const string code = @"
+using System.Threading.Tasks;
+class C
+{
+    public Task Foo()
+    {
+        [|Task.Delay(1)|];
+
+        return Task.CompletedTask;
+    }
+}";
+            return HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+        }
+
+
+
+        [Fact]
+        public Task GenericTaskOfValueTypeIsDropped()
+        {
+            const string code = @"
+using System.Threading.Tasks;
+class C
+{
+    public Task Foo()
+    {
+        [|Task.FromResult(0)|];
+
+        return Task.CompletedTask;
+    }
+}";
+            return HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+        }
+
+
+
+        [Fact]
+        public Task GenericTaskOfReferenceTypeIsDropped()
+        {
+            const string code = @"
+using System.Threading.Tasks;
+class C
+{
+    public Task Foo()
+    {
+        [|Task.FromResult(""string"")|];
+
+        return Task.CompletedTask;
+    }
+}";
+            return HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+        }
+
+
+
+        [Fact]
+        public Task InvokingTaskReturningFunc()
+        {
+            const string code = @"
+using System;
+using System.Threading.Tasks;
+class C
+{
+    public Task Foo()
+    {
+        Func<Task> func = () => Task.Delay(0);
+
+        [|func()|];
+
+        return Task.CompletedTask;
+    }
+}";
+            return HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+        }
+
+
+
+        [Fact]
+        public Task InvokingTaskReturningFunc_OkIfAwaited()
+        {
+            const string code = @"
+using System;
+using System.Threading.Tasks;
+class C
+{
+    public Task Foo()
+    {
+        Func<Task> func = () => Task.Delay(0);
+
+        await func();
+
+        return Task.CompletedTask;
+    }
+}";
+            return NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+        }
+
+
+
+        [Fact]
+        public Task InvokingTaskReturningDelegate()
+        {
+            const string code = @"
+using System;
+using System.Threading.Tasks;
+class C
+{
+    public Task Foo()
+    {
+        TaskyDelegate del = () => Task.Delay(0);
+
+        [|del()|];
+
+        return Task.CompletedTask;
+    }
+
+    public delegate Task TaskyDelegate();
+}";
+            return HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+        }
+
+
+
+        [Fact]
+        public Task InvokingTaskReturningDelegate_OkIfAwaited()
+        {
+            const string code = @"
+using System;
+using System.Threading.Tasks;
+class C
+{
+    public Task Foo()
+    {
+        TaskyDelegate del = () => Task.Delay(0);
+
+        await del();
+
+        return Task.CompletedTask;
+    }
+
+    public delegate Task TaskyDelegate();
+}";
+            return NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+        }
+
+
+
+        [Fact]
+        public Task TaskDroppedWithinFuncLambda()
+        {
+            const string code = @"
+using System;
+using System.Threading.Tasks;
+class C
+{
+    public Task Foo()
+    {
+        Func<Task> func = () => { [|Task.Delay(0)|]; return Task.Completed; }
+
+        return func();
+    }
+}";
+            return HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+        }
+
+
+
+
+
+        [Fact]
+        public Task BigLongFuncDoesNotMatter()
+        {
+            const string code = @"
+using System;
+using System.Threading.Tasks;
+class C
+{
+    public Task Foo()
+    {
+        Func<int,int,int,int,int,Task> func = (a,b,c,d,e) => { var task = Task.Delay(1); var tot = a+b+c+d+e; return task; }
+
+        return func(1,2,3,4,5);
+    }
+}";
+            return NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+        }
+    }
+}

--- a/src/Particular.CodeRules.Tests/Particular.CodeRules.Tests.csproj
+++ b/src/Particular.CodeRules.Tests/Particular.CodeRules.Tests.csproj
@@ -36,6 +36,7 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AwaitOrCaptureTasksAnalyzerTests.cs" />
     <Compile Include="ConfigureAwaitAnalyzerTests.cs" />
     <Compile Include="ConfigureAwaitCodeFixTests.cs" />
     <Compile Include="Helpers\AnalyzerTestFixture.cs" />

--- a/src/Particular.CodeRules/AwaitOrCaptureTasks/AwaitOrCaptureTasksAnalyzer.cs
+++ b/src/Particular.CodeRules/AwaitOrCaptureTasks/AwaitOrCaptureTasksAnalyzer.cs
@@ -1,0 +1,84 @@
+﻿namespace Particular.CodeRules.AwaitOrCaptureTasks
+{
+    using System.Collections.Immutable;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class AwaitOrCaptureTasksAnalyzer : DiagnosticAnalyzer
+    {
+        /// <summary>
+        ///     Gets the list of supported diagnostics for the analyzer.
+        /// </summary>
+        /// <value>
+        ///     The supported diagnostics.
+        /// </value>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.AwaitOrCaptureTasks);
+
+        /// <summary>
+        ///     Initializes the specified analyzer on the <paramref name="context" />.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.InvocationExpression);
+        }
+
+        private static void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
+        {
+            var node = context.Node as InvocationExpressionSyntax;
+            var parentNode = node?.Parent as ExpressionStatementSyntax;
+
+            if (parentNode != null)
+            {
+                var symbol = context.SemanticModel.GetSymbolInfo(node.Expression).Symbol;
+
+                if (IsDroppedTask(context, symbol))
+                {
+                    var location = node.GetLocation();
+                    var diagnostic = Diagnostic.Create(DiagnosticDescriptors.AwaitOrCaptureTasks, location);
+                    context.ReportDiagnostic(diagnostic);
+                }
+            }
+        }
+
+        private static bool IsDroppedTask(SyntaxNodeAnalysisContext context, ISymbol symbol)
+        {
+            if (symbol is IMethodSymbol)
+            {
+                return DerivesFromTask(context, ((IMethodSymbol)symbol).ReturnType);
+            }
+
+            if (symbol is ILocalSymbol)
+            {
+                // Possibly a Func or delegate that returns a Task
+                var namedType = ((ILocalSymbol)symbol).Type as INamedTypeSymbol;
+                if (namedType?.TypeKind == TypeKind.Delegate)
+                {
+                    var delegateInvoke = namedType.DelegateInvokeMethod;
+                    var returnType = delegateInvoke.ReturnType;
+                    return DerivesFromTask(context, returnType);
+                }
+            }
+
+            return false;
+        }
+
+        private static bool DerivesFromTask(SyntaxNodeAnalysisContext context, ITypeSymbol symbol)
+        {
+            while (symbol != null)
+            {
+                if (symbol.ToString() == "System.Threading.Tasks.Task")
+                {
+                    return true;
+                }
+
+                symbol = symbol.BaseType;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Particular.CodeRules/DiagnosticIds.cs
+++ b/src/Particular.CodeRules/DiagnosticIds.cs
@@ -5,6 +5,7 @@
     public static class DiagnosticIds
     {
         public const string UseConfigureAwait = "PCR0001";
+        public const string AwaitOrCaptureTasks = "PCR0002";
     }
 
     public static class DiagnosticDescriptors
@@ -16,6 +17,15 @@
             category: DiagnosticCategories.Code,
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor AwaitOrCaptureTasks = new DiagnosticDescriptor(
+            id: DiagnosticIds.AwaitOrCaptureTasks,
+            title: "Await or Capture Tasks",
+            messageFormat: "Expression creates a Task that is not awaited or assigned to a variable.",
+            category: "Code",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: "A method returning a Task should either be awaited or stored in a variable so that the Task is not dropped.");
     }
 
     internal static class DiagnosticCategories

--- a/src/Particular.CodeRules/Particular.CodeRules.csproj
+++ b/src/Particular.CodeRules/Particular.CodeRules.csproj
@@ -106,6 +106,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AwaitOrCaptureTasks\AwaitOrCaptureTasksAnalyzer.cs" />
     <Compile Include="ConfigureAwait\ConfigureAwaitAnalyzer.cs" />
     <Compile Include="ConfigureAwait\ConfigureAwaitCodeFix.cs" />
     <Compile Include="DiagnosticIds.cs" />


### PR DESCRIPTION
An additional analyzer to detect when a user drops a Task, i.e. does not either await it immediately or assign it to a variable.

If the user does assign it to a variable but then does not await that variable, that is still on them. It would be too difficult to efficiently follow that variable to its eventual demise. Designed mostly to help in situations upgrading to async where, if the `async` keyword is not added to a method, calls that return tasks won't be highlighted in any way by the compiler natively.

@distantcam @WilliamBZA What do you think?