### PR TITLE
handle NRE when analyzing dynamics in ConfigureAwaitAnalyzer

### DIFF
--- a/src/Particular.CodeRules.Tests/AwaitOrCaptureTasksAnalyzerTests.cs
+++ b/src/Particular.CodeRules.Tests/AwaitOrCaptureTasksAnalyzerTests.cs
@@ -78,6 +78,23 @@ class C
 
 
         [Fact]
+        public Task DynamicTaskIsDropped()
+        {
+            const string code = @"
+using System.Threading.Tasks;
+class C
+{
+    public Task Foo(dynamic x)
+    {
+        [|Foo(x)|];
+
+        return Task.CompletedTask;
+    }
+}";
+            return HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+        }
+
+        [Fact]
         public Task GenericTaskOfValueTypeIsDropped()
         {
             const string code = @"

--- a/src/Particular.CodeRules.Tests/ConfigureAwaitAnalyzerTests.cs
+++ b/src/Particular.CodeRules.Tests/ConfigureAwaitAnalyzerTests.cs
@@ -35,5 +35,21 @@ class C
 }";
             return NoDiagnostic(code, DiagnosticIds.UseConfigureAwait);
         }
+
+        [Fact]
+        public Task IgnoreDynamics()
+        {
+            const string code = @"
+using System.Threading.Tasks;
+class C
+{
+    public async Task Foo(dynamic x)
+    {
+        await Foo(x);
+    }
+}";
+
+            return NoDiagnostic(code, DiagnosticIds.UseConfigureAwait);
+        }
     }
 }

--- a/src/Particular.CodeRules.Tests/Helpers/TestHelpers.cs
+++ b/src/Particular.CodeRules.Tests/Helpers/TestHelpers.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Particular.CodeRules.Tests
@@ -65,6 +66,7 @@ namespace Particular.CodeRules.Tests
 
             return new AdhocWorkspace()
                 .AddProject("TestProject", languageName)
+                .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
                 .AddMetadataReferences(references)
                 .AddDocument("TestDocument", code);
         }

--- a/src/Particular.CodeRules.Tests/Particular.CodeRules.Tests.csproj
+++ b/src/Particular.CodeRules.Tests/Particular.CodeRules.Tests.csproj
@@ -74,6 +74,7 @@
       <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.1.1\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>

--- a/src/Particular.CodeRules/ConfigureAwait/ConfigureAwaitAnalyzer.cs
+++ b/src/Particular.CodeRules/ConfigureAwait/ConfigureAwaitAnalyzer.cs
@@ -32,7 +32,7 @@
 
         private void AnalyzeForConfigureFalse(SyntaxNodeAnalysisContext context)
         {
-            if (GeneratedCodeRecognition.IsFromGeneratedCode(context))
+            if (context.IsFromGeneratedCode())
             {
                 return;
             }
@@ -41,7 +41,7 @@
             if (node.Expression != null)
             {
                 var type = ModelExtensions.GetTypeInfo(context.SemanticModel, node.Expression).Type;
-                if (type.ContainingNamespace.ToString() == "System.Threading.Tasks" && type.Name == "Task")
+                if (type.ContainingNamespace?.ToString() == "System.Threading.Tasks" && type.Name == "Task")
                 {
                     context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.UseConfigureAwait, node.GetLocation()));
                 }


### PR DESCRIPTION
Fixes https://github.com/Particular/Particular.CodeRules/issues/4

When calling async methods which accept a dynamic parameter, the return type might become dynamic as well. In that case, the type doesn't have a namespace and trying to check the namespace causes a NRE which should be prevented as this shows up as an error when building.

This PR just tries to prevent the NRE, it does not "fix" it completely (by showing a missing `ConfigureAwait` warning in such cases).

Added unit tests for both analyzers to ensure dynamic "compatibility". This required some tweaking of the helper methods in order to be able to catch analyzer exceptions.