### PR TITLE
Add direct GitVersionTask reference

### DIFF
--- a/src/Particular.CodeRules/Particular.CodeRules.csproj
+++ b/src/Particular.CodeRules/Particular.CodeRules.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.2.2" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="All" />


### PR DESCRIPTION
This works around the fact that the GitVersionTask dependency of Particular.Packaging is currently scoped to `net452` and `netstandard2.0` only, meaning any other TFM won't include the reference.

