### PR TITLE
add StyleCop.Analyzers

### DIFF
--- a/src/Particular.CodeRules.Tests/AwaitOrCaptureTasksAnalyzerTests.cs
+++ b/src/Particular.CodeRules.Tests/AwaitOrCaptureTasksAnalyzerTests.cs
@@ -18,7 +18,7 @@ class C
         await Task.Delay(1);
     }
 }";
-            return NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+            return this.NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
         }
 
 
@@ -36,7 +36,7 @@ class C
         return task;
     }
 }";
-            return NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+            return this.NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
         }
 
 
@@ -53,7 +53,7 @@ class C
         return Task.Delay(1);
     }
 }";
-            return NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+            return this.NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
         }
 
 
@@ -72,7 +72,7 @@ class C
         return Task.CompletedTask;
     }
 }";
-            return HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+            return this.HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
         }
 
 
@@ -91,7 +91,7 @@ class C
         return Task.CompletedTask;
     }
 }";
-            return HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+            return this.HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
         }
 
         [Fact]
@@ -108,7 +108,7 @@ class C
         return Task.CompletedTask;
     }
 }";
-            return HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+            return this.HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
         }
 
 
@@ -127,7 +127,7 @@ class C
         return Task.CompletedTask;
     }
 }";
-            return HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+            return this.HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
         }
 
 
@@ -149,7 +149,7 @@ class C
         return Task.CompletedTask;
     }
 }";
-            return HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+            return this.HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
         }
 
 
@@ -171,7 +171,7 @@ class C
         return Task.CompletedTask;
     }
 }";
-            return NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+            return this.NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
         }
 
 
@@ -195,7 +195,7 @@ class C
 
     public delegate Task TaskyDelegate();
 }";
-            return HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+            return this.HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
         }
 
 
@@ -219,7 +219,7 @@ class C
 
     public delegate Task TaskyDelegate();
 }";
-            return NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+            return this.NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
         }
 
 
@@ -239,7 +239,7 @@ class C
         return func();
     }
 }";
-            return HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+            return this.HasDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
         }
 
 
@@ -261,7 +261,7 @@ class C
         return func(1,2,3,4,5);
     }
 }";
-            return NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
+            return this.NoDiagnostic(code, DiagnosticIds.AwaitOrCaptureTasks);
         }
     }
 }

--- a/src/Particular.CodeRules.Tests/GlobalSuppressions.cs
+++ b/src/Particular.CodeRules.Tests/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Tests")]

--- a/src/Particular.CodeRules.Tests/Helpers/AnalyzerTestFixture.cs
+++ b/src/Particular.CodeRules.Tests/Helpers/AnalyzerTestFixture.cs
@@ -1,15 +1,15 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Runtime.ExceptionServices;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
-using Xunit;
-
-namespace Particular.CodeRules.Tests
+﻿namespace Particular.CodeRules.Tests
 {
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Runtime.ExceptionServices;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.CodeAnalysis.Text;
+    using Xunit;
+
     public class CSharpAnalyzerTestFixture<TAnalyzer> : AnalyzerTestFixture where TAnalyzer : DiagnosticAnalyzer, new()
     {
         protected override string LanguageName => LanguageNames.CSharp;
@@ -23,13 +23,13 @@ namespace Particular.CodeRules.Tests
 
         protected Task NoDiagnostic(string code, string diagnosticId)
         {
-            var document = TestHelpers.GetDocument(code, LanguageName);
-            return NoDiagnostic(document, diagnosticId);
+            var document = TestHelpers.GetDocument(code, this.LanguageName);
+            return this.NoDiagnostic(document, diagnosticId);
         }
 
         protected async Task NoDiagnostic(Document document, string diagnosticId)
         {
-            var diagnostics = await GetDiagnostics(document);
+            var diagnostics = await this.GetDiagnostics(document);
             Assert.Empty(diagnostics);
         }
 
@@ -37,14 +37,14 @@ namespace Particular.CodeRules.Tests
         {
             Document document;
             TextSpan span;
-            Assert.True(TestHelpers.TryGetDocumentAndSpanFromMarkup(markupCode, LanguageName, out document, out span), "No markup detected in test code.");
+            Assert.True(TestHelpers.TryGetDocumentAndSpanFromMarkup(markupCode, this.LanguageName, out document, out span), "No markup detected in test code.");
 
-            return HasDiagnostic(document, span, diagnosticId);
+            return this.HasDiagnostic(document, span, diagnosticId);
         }
 
         protected async Task HasDiagnostic(Document document, TextSpan span, string diagnosticId)
         {
-            var diagnostics = await GetDiagnostics(document);
+            var diagnostics = await this.GetDiagnostics(document);
             Assert.Single(diagnostics);
 
             var diagnostic = diagnostics[0];
@@ -55,7 +55,7 @@ namespace Particular.CodeRules.Tests
 
         private async Task<ImmutableArray<Diagnostic>> GetDiagnostics(Document document)
         {
-            var analyzers = ImmutableArray.Create(CreateAnalyzer());
+            var analyzers = ImmutableArray.Create(this.CreateAnalyzer());
             var exceptions = new List<ExceptionDispatchInfo>();
             var compilation = await document.Project.GetCompilationAsync(CancellationToken.None);
             var analyzerOptions = new CompilationWithAnalyzersOptions(

--- a/src/Particular.CodeRules.Tests/Helpers/ReflectionExtensions.cs
+++ b/src/Particular.CodeRules.Tests/Helpers/ReflectionExtensions.cs
@@ -1,16 +1,16 @@
-﻿using System;
-using System.Reflection;
-using Microsoft.CodeAnalysis;
-
-namespace Particular.CodeRules.Tests
+﻿namespace Particular.CodeRules.Tests
 {
+    using System;
+    using System.Reflection;
+    using Microsoft.CodeAnalysis;
+
     internal static class ReflectionExtensions
     {
         private static class AssemblyLightUp
         {
             internal static readonly Type Type = typeof(Assembly);
 
-            internal static readonly Func<Assembly, string> get_Location = Type
+            internal static readonly Func<Assembly, string> GetLocation = Type
                 .GetTypeInfo()
                 .GetDeclaredMethod("get_Location")
                 .CreateDelegate<Func<Assembly, string>>();
@@ -18,12 +18,12 @@ namespace Particular.CodeRules.Tests
 
         public static string GetLocation(this Assembly assembly)
         {
-            if (AssemblyLightUp.get_Location == null)
+            if (AssemblyLightUp.GetLocation == null)
             {
                 throw new PlatformNotSupportedException();
             }
 
-            return AssemblyLightUp.get_Location(assembly);
+            return AssemblyLightUp.GetLocation(assembly);
         }
 
         public static T CreateDelegate<T>(this MethodInfo methodInfo)

--- a/src/Particular.CodeRules.Tests/Helpers/TestHelpers.cs
+++ b/src/Particular.CodeRules.Tests/Helpers/TestHelpers.cs
@@ -1,13 +1,13 @@
-﻿using System.Collections.Immutable;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
-
-namespace Particular.CodeRules.Tests
+﻿namespace Particular.CodeRules.Tests
 {
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Text;
+
     public static class TestHelpers
     {
         public static bool TryGetCodeAndSpanFromMarkup(string markupCode, out string code, out TextSpan span)

--- a/src/Particular.CodeRules.sln
+++ b/src/Particular.CodeRules.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2042
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30413.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Particular.CodeRules", "Particular.CodeRules\Particular.CodeRules.csproj", "{3DEB4013-558D-4711-8622-E31CA878660D}"
 EndProject
@@ -10,7 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Particular.CodeRules.Tests", "Particular.CodeRules.Tests\Particular.CodeRules.Tests.csproj", "{F2FD606D-A9DB-42B6-A22D-56B1CC8CCB88}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Particular.CodeRules.Tests", "Particular.CodeRules.Tests\Particular.CodeRules.Tests.csproj", "{F2FD606D-A9DB-42B6-A22D-56B1CC8CCB88}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Particular.CodeRules/Particular.CodeRules.csproj
+++ b/src/Particular.CodeRules/Particular.CodeRules.csproj
@@ -19,12 +19,14 @@
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" PrivateAssets="None" />
     <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="None" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Link="$(AssemblyName).dll" Visible="false" />
     <None Update="Particular.CodeRules.props" Pack="true" PackagePath="build" />
     <None Update="Particular.ruleset" Pack="true" PackagePath="build" />
+    <None Update="stylecop.json" Pack="true" PackagePath="build" />
     <None Update="tools\*.ps1" Pack="true" PackagePath="tools\%(Filename)%(Extension)" />
   </ItemGroup>
 

--- a/src/Particular.CodeRules/Particular.CodeRules.props
+++ b/src/Particular.CodeRules/Particular.CodeRules.props
@@ -4,4 +4,8 @@
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)Particular.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
 </Project>

--- a/src/Particular.CodeRules/Particular.ruleset
+++ b/src/Particular.CodeRules/Particular.ruleset
@@ -230,4 +230,57 @@
     <Rule Id="CA5403" Action="None" />             <!-- Do not hard-code certificate -->
     <Rule Id="CA9999" Action="None" />             <!-- Analyzer version mismatch -->
   </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <!-- rules we may want to enforce eventually -->
+    <Rule Id="SA0001" Action="None" />             <!-- XML comment analysis disabled -->
+    <Rule Id="SA1005" Action="None" />             <!-- Single line comments should begin with single space -->
+    <Rule Id="SA1009" Action="None" />             <!-- Closing parenthesis should be spaced correctly -->
+    <Rule Id="SA1012" Action="None" />             <!-- Opening braces should be spaced correctly -->
+    <Rule Id="SA1013" Action="None" />             <!-- Closing braces should be spaced correctly -->
+    <Rule Id="SA1028" Action="None" />             <!-- Code should not contain trailing whitespace -->
+    <Rule Id="SA1127" Action="None" />             <!-- Generic type constraints should be on their own line -->
+    <Rule Id="SA1128" Action="None" />             <!-- Put constructor initializers on their own line -->
+    <Rule Id="SA1135" Action="None" />             <!-- Using directives should be qualified -->
+    <Rule Id="SA1201" Action="None" />             <!-- Elements should appear in the correct order -->
+    <Rule Id="SA1202" Action="None" />             <!-- Elements should be ordered by access -->
+    <Rule Id="SA1203" Action="None" />             <!-- Constants should appear before fields -->
+    <Rule Id="SA1204" Action="None" />             <!-- Static elements should appear before instance elements -->
+    <Rule Id="SA1205" Action="None" />             <!-- Partial elements should declare access -->
+    <Rule Id="SA1208" Action="None" />             <!-- System using directives should be placed before other using directives -->
+    <Rule Id="SA1214" Action="None" />             <!-- Readonly fields should appear before non-readonly fields -->
+    <Rule Id="SA1302" Action="None" />             <!-- Interface names should begin with I -->
+    <Rule Id="SA1306" Action="None" />             <!-- Field names should begin with lower-case letter -->
+    <Rule Id="SA1307" Action="None" />             <!-- Accessible fields should begin with upper-case letter -->
+    <Rule Id="SA1311" Action="None" />             <!-- Static readonly fields should begin with upper-case letter -->
+    <Rule Id="SA1314" Action="None" />             <!-- Type parameter names should begin with T -->
+    <Rule Id="SA1400" Action="None" />             <!-- Access modifier should be declared -->
+    <Rule Id="SA1401" Action="None" />             <!-- Fields should be private -->
+    <Rule Id="SA1402" Action="None" />             <!-- File may only contain a single type -->
+    <Rule Id="SA1403" Action="None" />             <!-- File may only contain a single namespace -->
+    <Rule Id="SA1413" Action="None" />             <!-- Use trailing comma in multi-line initializers -->
+    <Rule Id="SA1501" Action="None" />             <!-- Statement should not be on a single line -->
+    <Rule Id="SA1502" Action="None" />             <!-- Element should not be on a single line -->
+    <Rule Id="SA1503" Action="None" />             <!-- Braces should not be omitted -->
+    <Rule Id="SA1505" Action="None" />             <!-- Opening braces should not be followed by blank line -->
+    <Rule Id="SA1507" Action="None" />             <!-- Code should not contain multiple blank lines in a row -->
+    <Rule Id="SA1513" Action="None" />             <!-- Closing brace should be followed by blank line -->
+    <Rule Id="SA1515" Action="None" />             <!-- Single-line comment should be preceded by blank line -->
+    <Rule Id="SA1516" Action="None" />             <!-- Elements should be separated by blank line -->
+    <Rule Id="SA1602" Action="None" />             <!-- Enumeration items should be documented -->
+    <Rule Id="SA1611" Action="None" />             <!-- Element parameters should be documented -->
+    <Rule Id="SA1615" Action="None" />             <!-- Element return value should be documented -->
+    <Rule Id="SA1618" Action="None" />             <!-- Generic type parameters should be documented -->
+    
+    <!-- when enabled this rule, we should also remove NServiceBus.Core.Tests.DocumentationTests.EnsureNoDocumentationIsEmpty -->
+    <Rule Id="SA1629" Action="None" />             <!-- Documentation text should end with a period -->
+    <Rule Id="SA1649" Action="None" />             <!-- File name should match first type name -->
+
+
+
+    <!-- rules we have decided not to enforce -->
+    <Rule Id="SA1122" Action="None" />             <!-- Use string.Empty for empty strings -->
+    <Rule Id="SA1601" Action="None" />             <!-- Partial elements should be documented -->
+    <Rule Id="SA1623" Action="None" />             <!-- Property summary documentation should match accessors -->
+    <Rule Id="SA1633" Action="None" />             <!-- File should have header -->
+  </Rules>
 </RuleSet>

--- a/src/Particular.CodeRules/stylecop.json
+++ b/src/Particular.CodeRules/stylecop.json
@@ -1,0 +1,5 @@
+﻿{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+  }
+}


### PR DESCRIPTION
The rules listed in the PR cover two categories:

1) Rules that we feel should be reviewed by future task forces (or possibly small tasks) and that could be re-enforced later
2) Rules that we feel we don't need to enforce

The rules listed below are left enabled and will cause build errors once this PR is merged and deployed and dependabot raises PRs for downstream repos. The current task force will fix violations in our repos as we update to the new version of Particular.CodeRules. Our criteria for selecting rules for this category (as opposed to category 1 above) was simply because the number of violations is small enough that fixing them would be within the time box of the current task force.

What we would like reviewed is the list of rules we plan to enforce and the ones we won't. Please provide opinions on why you feel a selected rule should or should not be included in the list.

*NOTE*: Rules listed in the PR are _exclusions_. I.e. if they are in the list, Visual Studio will _not_ check for code that violates them.

### Rules we will fix as part of this TF

Check Id | Description 
-- | --
[SA1000](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md)|The spacing around a C# keyword is incorrect.
[SA1001](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md)|The spacing around a comma is incorrect, within a C# code file.
[SA1002](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1002.md)|The spacing around a semicolon is incorrect, within a C# code file.
[SA1003](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1003.md)|The spacing around an operator symbol is incorrect, within a C# code file.
[SA1004](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1004.md)|A line within a documentation header above a C# element does not begin with a single space.
[SA1008](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1008.md)|An opening parenthesis within a C# statement is not spaced correctly.
[SA1011](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1011.md)|A closing square bracket within a C# statement is not spaced correctly.
[SA1020](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1020.md)|An increment or decrement symbol within a C# element is not spaced correctly.
[SA1024](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1024.md)|A colon within a C# element is not spaced correctly.
[SA1025](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1025.md)|The code contains multiple whitespace characters in a row.
[SA1026](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1026.md)|An implicitly typed array allocation within a C# code file is not spaced correctly.
[SA1027](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1027.md)|The code contains a tab or space character which is not consistent with the current project settings.
[SA1101](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md)|A call to an instance member of the local class or a base class is not prefixed with 'this.', within a C# code file.
[SA1108](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1108.md)|A C# statement contains a comment between the declaration of the statement and the opening brace of the statement.
[SA1110](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1110.md)|The opening parenthesis or bracket in a call to a C# method or indexer, or the declaration of a method or indexer, is
[SA1111](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1111.md)|The closing parenthesis or bracket in a call to a C# method or indexer, or the declaration of a method or indexer, is not placed on the same line as the last parameter.
[SA1115](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1115.md)|A parameter within a C# method or indexer call or declaration does not begin on the same line as the previous parameter, or on the next line.
[SA1116](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1116.md)|The parameters to a C# method or indexer call or declaration span across multiple lines, but the first parameter does not start on the line after the opening bracket.
[SA1117](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1117.md)|The parameters to a C# method or indexer call or declaration are not all on the same line or each on a separate line.
[SA1118](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1118.md)|A parameter to a C# method or indexer, other than the first parameter, spans across multiple lines.
[SA1119](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md)|A C# statement contains parenthesis which are unnecessary and should be removed.
[SA1129](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1129.md)|A value type was constructed using the syntax `new T()`.
[SA1131](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1131.md)|A comparison was made between a variable and a literal or constant value, and the variable appeared on the right-hand
[SA1133](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1133.md)|Two or more attributes appeared within the same set of square brackets.
[SA1136](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1136.md)|Multiple enum values are placed on the same line of code.
[SA1137](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1137.md)|Two sibling elements which each start on their own line have different levels of indentation.
[SA1200](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md)|A C# using directive is placed outside of a namespace element.
[SA1207](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1207.md)|The keyword *protected* is positioned after the keyword *internal* within the declaration of a protected internal C# element, or the keyword *private* is positioned after the keyword *protected*.
[SA1210](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1210.md)|The using directives within a C# code file are not sorted alphabetically by namespace.
[SA1300](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md)|The name of a C# element does not begin with an upper-case letter.
[SA1303](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md)|The name of a constant C# field should begin with an upper-case letter.
[SA1304](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md)|The name of a non-private readonly C# field should being with an upper-case letter.
[SA1309](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1309.md)|A field name in C# begins with an underscore.
[SA1310](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1310.md)|A field name in C# contains an underscore.
[SA1407](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1407.md)|A C# statement contains a complex arithmetic expression which omits parenthesis around operators.
[SA1408](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1408.md)|A C# statement contains a complex conditional expression which omits parenthesis around operators.
[SA1500](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1500.md)|The opening or closing brace within a C# statement, element, or expression is not placed on its own line.
[SA1504](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1504.md)|Within a C# property, indexer or event, at least one of the child accessors is written on a single line, and at least one of the child accessors is written across multiple lines.
[SA1508](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1508.md)|A closing brace within a C# element, statement, or expression is preceded by a blank line.
[SA1509](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1509.md)|An opening brace within a C# element, statement, or expression is preceded by a blank line.
[SA1511](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1511.md)|The while footer at the bottom of a do-while statement is separated from the statement by a blank line.
[SA1512](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1512.md)|A single-line comment within C# code is followed by a blank line.
[SA1514](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1514.md)|An element documentation header above a C# element is not preceded by a blank line.
[SA1517](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1517.md)|The code file has blank lines at the start.
[SA1519](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1519.md)|The opening and closing braces for a multi-line C# statement have been omitted.
[SA1600](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1600.md)|A C# code element is missing a documentation header.
[SA1604](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1604.md)|The Xml header documentation for a C# element is missing a `<summary>` tag.
[SA1612](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1612.md)|The documentation describing the parameters to a C# method, constructor, delegate or indexer element does not match the actual parameters on the element.
[SA1625](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1625.md)|The Xml documentation for a C# element contains two or more identical entries, indicating that the documentation has been copied and pasted. This can sometimes indicate invalid or poorly written documentation.
[SA1642](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1642.md)|The XML documentation header for a C# constructor does not contain the appropriate summary text.
[SA1648](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1648.md)|`<inheritdoc>` has been used on an element that doesn't inherit from a base class or implement an interface.