### PR TITLE
Only require documentation for public types

### DIFF
--- a/src/Particular.CodeRules/stylecop.json
+++ b/src/Particular.CodeRules/stylecop.json
@@ -1,5 +1,9 @@
 ﻿{
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
+    "documentationRules": {
+      "documentInterfaces": false,
+      "documentInternalElements": false
+    }
   }
 }


### PR DESCRIPTION
All internal types and interfaces are requiring documentation by default with 1600 per https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/Configuration.md#documentation-requirements

Adding this to the `stylecop.json`, in my own testing, configures the rule appropriately for our previous expectations (only publicly exposed types require documentation).