### PR TITLE
Disable SA1512

### DIFF
--- a/src/Particular.CodeRules/Particular.ruleset
+++ b/src/Particular.CodeRules/Particular.ruleset
@@ -297,6 +297,7 @@
     <Rule Id="SA1505" Action="None" />             <!-- Opening braces should not be followed by blank line -->
     <Rule Id="SA1507" Action="None" />             <!-- Code should not contain multiple blank lines in a row -->
     <Rule Id="SA1508" Action="None" />             <!-- Closing braces should not be preceded by blank line -->
+    <Rule Id="SA1512" Action="None" />             <!-- Single-line comments should not be followed by blank line -->
     <Rule Id="SA1513" Action="None" />             <!-- Closing brace should be followed by blank line -->
     <Rule Id="SA1515" Action="None" />             <!-- Single-line comment should be preceded by blank line -->
     <Rule Id="SA1516" Action="None" />             <!-- Elements should be separated by blank line -->


### PR DESCRIPTION
This rule shows errors for every comment using `//` that might have an empty next line. This can typically happen when refactoring some code and the rule is super annoying because it blocks the complete build for something absolutely trivial and meaningless. Therefore I propose to disable that rule the same way we disabled also the following rule already:

`<Rule Id="SA1005" Action="None" />             <!-- Single line comments should begin with single space -->`