### PR TITLE
Remove unneeded warning suppression

### DIFF
--- a/src/Particular.CodeRules.Tests/Particular.CodeRules.Tests.csproj
+++ b/src/Particular.CodeRules.Tests/Particular.CodeRules.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Particular.CodeRules.Tests/Particular.CodeRules.Tests.csproj
+++ b/src/Particular.CodeRules.Tests/Particular.CodeRules.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
-    <NoWarn>$(NoWarn);NU1701</NoWarn>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/Particular.CodeRules/Particular.CodeRules.csproj
+++ b/src/Particular.CodeRules/Particular.CodeRules.csproj
@@ -18,13 +18,13 @@
     <PackageReference Update="NETStandard.Library" PrivateAssets="All" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <None Remove="AnalyzerReleases.Shipped.md" />
     <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
     <None Remove="AnalyzerReleases.Unshipped.md" />
     <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
   </ItemGroup>
-   
+
   <ItemGroup>
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Link="$(AssemblyName).dll" Visible="false" />
     <None Update="tools\*.ps1" Pack="true" PackagePath="tools\%(Filename)%(Extension)" />

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="particular myget.org" value="https://www.myget.org/F/particular/api/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
@adamralph A follow-up to #56. The package update means the warning suppression is no longer needed.