### PR TITLE
fix nuget push in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
         env:
           API_KEY: ${{ secrets.MYGET_PUBLISH_API_KEY }}
         if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/tags/')) && env.API_KEY != ''
-        run: dotnet nuget push nugets/*.nupkg --source https://www.myget.org/F/particular/api/v2/package --api-key ${{ env.API_KEY }}
+        run: dotnet nuget push nugets/**/*.nupkg --source https://www.myget.org/F/particular/api/v2/package --api-key ${{ env.API_KEY }}


### PR DESCRIPTION
Currently [doesn't work](https://github.com/Particular/Particular.CodeRules/runs/2154376754?check_suite_focus=true).

I've no idea why it needs the folder wildcard, but I've confirmed locally that this works. Also, this is how I do it in my personal projects, but in those, the packages are in deep subfolders, whereas here they are just in `nugets/`, which is why I thought the folder wildcard wasn't required.